### PR TITLE
Can't read books that added by relative path

### DIFF
--- a/lib/honyomi/core.rb
+++ b/lib/honyomi/core.rb
@@ -24,6 +24,7 @@ module Honyomi
 
     def add(filename, options = {})
       if File.exist?(filename)
+        filename = File.expand_path(filename)
         options = options.dup
         pages = Pdf.new(filename).pages
         pages = pages.map { |page| Util.strip_page(page) } if options[:strip]

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -21,6 +21,21 @@ module Honyomi
       end
     end
 
+    def test_add_by_relative_path
+      Dir.mktmpdir do |dir|
+        core = Core.new({home_dir: dir})
+        core.init_database
+
+        absolute_path = File.expand_path(datafile("test.pdf"))
+        relative_path = Pathname.new(datafile("test.pdf")).relative_path_from(Pathname.new(Dir.getwd)).to_s
+        assert absolute_path != relative_path
+
+        core.add(relative_path)
+
+        assert_equal absolute_path, core.database.books[1].path
+      end
+    end
+
     def test_add_same_name
       Dir.mktmpdir do |dir|
         core = Core.new({home_dir: dir})


### PR DESCRIPTION
I added book by relative path.

```
$ honyomi add relative/path/to/book
```

And launch web interface.

```
$ honyomi web
```

Search the book and click to raise Errno::ENOENT.

```
Errno::ENOENT at /v/1
No such file or directory @ rb_file_s_stat - relative/path/to/book
```

I added `filename = File.expand_path(filename)` in `Honyomi::Core#add` to fix it. Is there better way?
