### PR TITLE
Can't add the book that has file name includes parenthesis.

### DIFF
--- a/lib/honyomi/pdf.rb
+++ b/lib/honyomi/pdf.rb
@@ -8,7 +8,7 @@ module Honyomi
 
       Dir.mktmpdir do |dir|
         outfile = File.join(dir, "pdf.txt")
-        system("pdftotext #{filename.gsub(' ', '\ ')} #{outfile}") # Need pdftotext (poppler, xpdf)
+        system("pdftotext", filename, outfile) # Need pdftotext (poppler, xpdf)
         @text = File.read(outfile)
       end
     end

--- a/test/test_pdf.rb
+++ b/test/test_pdf.rb
@@ -4,7 +4,7 @@ class TestPdf < MiniTest::Test
   def test_pdf
     File.join(File.dirname(__FILE__), "test.pdf")
   end
-  
+
   def test_pages
     pdf = Honyomi::Pdf.new(test_pdf)
 
@@ -12,5 +12,16 @@ class TestPdf < MiniTest::Test
     assert_equal "aaa\n\n", pdf.pages[0]
     assert_equal "bbb\n\n", pdf.pages[1]
     assert_equal "ccc\n\n", pdf.pages[2]
+  end
+
+  def test_file_name_includes_special_characters
+    Dir.mktmpdir do |dir|
+      filename = File.join(dir, "test (1).pdf")
+
+      FileUtils.cp test_pdf, filename
+      pdf = Honyomi::Pdf.new(filename)
+
+      assert_equal 3, pdf.pages.size
+    end
   end
 end


### PR DESCRIPTION
I couldn't add the book that has file name includes parenthesis.

```
$ honyomi add "test (1).pdf"
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `pdftotext path/to/test\ (1).pdf /path/to/tmp/pdf.txt'
Not found 'pdftotext' command (poppler, xpdf)
```

I changed `pdftotext` command invoking.
